### PR TITLE
Automatically convert pins to correct mode in `Channel::with_pins`

### DIFF
--- a/hal/src/peripherals/adc/d5x/pin.rs
+++ b/hal/src/peripherals/adc/d5x/pin.rs
@@ -1,7 +1,7 @@
 use crate::adc::*;
 use atsamd_hal_macros::hal_cfg;
 
-use crate::gpio::{self, pin::*, PinMode};
+use crate::gpio::{pin::*, PinMode};
 
 macro_rules! adc_pins {
     (
@@ -14,11 +14,11 @@ macro_rules! adc_pins {
         crate::paste::item! {
             $(
                 $( #[$cfg] )?
-                impl AdcPin<[<$Adc>], [<Ch $CHAN>]>for Pin<$PinId, AlternateB> {
-                    type Configured = Self;
+                impl<M: PinMode> AdcPin<$Adc, [<Ch $CHAN>]> for Pin<$PinId, M> {
+                    type Configured = Pin<$PinId, AlternateB>;
 
                     fn into_function(self) -> Self::Configured {
-                        self
+                        self.into_alternate()
                     }
                 }
             )+

--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -1,8 +1,7 @@
 use core::{marker::PhantomData, ops::Deref};
 
 use atsamd_hal_macros::{hal_cfg, hal_module};
-use atsame51j::Peripherals;
-use pac::Mclk;
+use pac::{Mclk, Peripherals};
 use seq_macro::seq;
 
 use crate::{
@@ -20,10 +19,7 @@ mod adc_settings;
 
 pub use adc_settings::*;
 
-use super::{
-    calibration,
-    clock::{self, Adc0Clock},
-};
+use super::{calibration, clock};
 
 /// Marker type that represents an ADC channel capable of doing async
 /// operations.


### PR DESCRIPTION
Small change to the AdcPin implementation to allow for unconfigured pins to be passed to `Channel::with_pin`