### PR TITLE
ADC v2: Remove Channel machinery, fully use `v2` clocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [workspace]
 resolver = "2"
 default-members = ["hal"]
-members = ["hal", "atsamd-hal-macros", "pac/*", "boards/*"]
+members = [
+	"hal",
+	"atsamd-hal-macros",
+	"pac/*",
+	"boards/*"
+]
 
 [profile.dev]
 debug = true

--- a/hal/src/peripherals/adc/d11/pin.rs
+++ b/hal/src/peripherals/adc/d11/pin.rs
@@ -13,12 +13,8 @@ macro_rules! adc_pins {
         crate::paste::item! {
             $(
                 $( #[$cfg] )?
-                impl<M: PinMode> AdcPin<$Adc, [<Ch $CHAN>]> for Pin<$PinId, M> {
-                    type Configured = Pin<$PinId, AlternateB>;
-
-                    fn into_function(self) -> Self::Configured {
-                        self.into_alternate()
-                    }
+                impl AdcPin<$Adc> for Pin<$PinId, AlternateB> {
+                    const CHANNEL: u8 = $CHAN;
                 }
             )+
         }

--- a/hal/src/peripherals/adc/d5x/mod.rs
+++ b/hal/src/peripherals/adc/d5x/mod.rs
@@ -3,8 +3,7 @@ pub mod pin;
 use pac::adc0::avgctrl::Samplenumselect;
 use pac::adc0::ctrlb::Resselselect;
 
-use super::{Adc, AdcAccumulation, Config, Error, Flags};
-use super::{AdcInstance, PrimaryAdc};
+use super::{Adc, AdcAccumulation, AdcInstance, Config, Error, Flags, PrimaryAdc};
 use crate::typelevel::NoneT;
 use crate::{calibration, pac};
 
@@ -16,7 +15,8 @@ impl PrimaryAdc for Adc0 {}
 
 impl AdcInstance for Adc0 {
     type Instance = pac::Adc0;
-    type Clock = crate::clock::Adc0Clock;
+
+    type ClockId = crate::clock::v2::pclk::ids::Adc0;
 
     #[cfg(feature = "async")]
     type Interrupt = crate::async_hal::interrupts::ADC0;
@@ -24,11 +24,6 @@ impl AdcInstance for Adc0 {
     #[inline]
     fn peripheral_reg_block(p: &mut pac::Peripherals) -> &pac::adc0::RegisterBlock {
         &p.adc0
-    }
-
-    #[inline]
-    fn enable_mclk(mclk: &mut pac::Mclk) {
-        mclk.apbdmask().modify(|_, w| w.adc0_().set_bit());
     }
 
     #[inline]
@@ -54,7 +49,8 @@ pub struct Adc1 {
 
 impl AdcInstance for Adc1 {
     type Instance = pac::Adc1;
-    type Clock = crate::clock::Adc1Clock;
+
+    type ClockId = crate::clock::v2::pclk::ids::Adc1;
 
     #[cfg(feature = "async")]
     type Interrupt = crate::async_hal::interrupts::ADC1;
@@ -62,11 +58,6 @@ impl AdcInstance for Adc1 {
     #[inline]
     fn peripheral_reg_block(p: &mut pac::Peripherals) -> &pac::adc0::RegisterBlock {
         &p.adc1
-    }
-
-    #[inline]
-    fn enable_mclk(mclk: &mut pac::Mclk) {
-        mclk.apbdmask().modify(|_, w| w.adc1_().set_bit());
     }
 
     #[inline]

--- a/hal/src/peripherals/adc/d5x/mod.rs
+++ b/hal/src/peripherals/adc/d5x/mod.rs
@@ -167,8 +167,8 @@ impl<I: AdcInstance + PrimaryAdc, F> Adc<I, F> {
         if vref.tsen().bit_is_clear() || vref.ondemand().bit_is_clear() {
             return Err(Error::TemperatureSensorNotEnabled);
         }
-        let mut tp = self.read_blocking(0x1C) as f32;
-        let mut tc = self.read_blocking(0x1D) as f32;
+        let mut tp = self.read_blocking_channel(0x1C) as f32;
+        let mut tc = self.read_blocking_channel(0x1D) as f32;
 
         if let AdcAccumulation::Summed(sum) = self.cfg.accumulation {
             // to prevent incorrect readings, divide by number of samples if the

--- a/hal/src/peripherals/adc/d5x/pin.rs
+++ b/hal/src/peripherals/adc/d5x/pin.rs
@@ -13,12 +13,8 @@ macro_rules! adc_pins {
         crate::paste::item! {
             $(
                 $( #[$cfg] )?
-                impl<M: PinMode> AdcPin<$Adc, [<Ch $CHAN>]> for Pin<$PinId, M> {
-                    type Configured = Pin<$PinId, AlternateB>;
-
-                    fn into_function(self) -> Self::Configured {
-                        self.into_alternate()
-                    }
+                impl AdcPin<$Adc> for Pin<$PinId, AlternateB> {
+                    const CHANNEL: u8 = $CHAN;
                 }
             )+
         }


### PR DESCRIPTION
* Take full advantage of the typelevel guarantees laid out by `clock::v2`
* Remove the `Channel` machinery, as it was introducing large amounts of unnecessary complexity