### PR TITLE
Fix overrun errors on thumbv6 targets

### DIFF
--- a/boards/feather_m0/examples/adc.rs
+++ b/boards/feather_m0/examples/adc.rs
@@ -39,7 +39,8 @@ fn main() -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div64)
+        // Overruns if clock divider < 128 in debug mode
+        .clock_divider(Prescaler::Div128)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/boards/feather_m0/examples/adc.rs
+++ b/boards/feather_m0/examples/adc.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div32)
+        .clock_divider(Prescaler::Div64)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/boards/feather_m0/examples/async_adc.rs
+++ b/boards/feather_m0/examples/async_adc.rs
@@ -42,7 +42,7 @@ async fn main(_s: embassy_executor::Spawner) -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div32)
+        .clock_divider(Prescaler::Div64)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/boards/feather_m0/examples/async_adc.rs
+++ b/boards/feather_m0/examples/async_adc.rs
@@ -42,7 +42,8 @@ async fn main(_s: embassy_executor::Spawner) -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div64)
+        // Overruns if clock divider < 128 in debug mode
+        .clock_divider(Prescaler::Div128)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/boards/pygamer/examples/neopixel_button.rs
+++ b/boards/pygamer/examples/neopixel_button.rs
@@ -10,12 +10,13 @@
 #![no_std]
 #![no_main]
 
+use atsamd_hal::adc::Config;
 #[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer::{self as bsp, entry, hal, pac, pins::Keys, Pins};
 
 use bsp::util::map_from;
-use hal::adc::Adc;
+use hal::adc::{Accumulation, Adc, Config, Prescaler, Resolution};
 use hal::{clock::GenericClockController, delay::Delay};
 
 use pac::gclk::pchctrl::Genselect::Gclk11;
@@ -47,7 +48,13 @@ fn main() -> ! {
 
     let mut buttons = pins.buttons.init();
 
-    let mut adc1 = Adc::adc1(peripherals.adc1, &mut peripherals.mclk, &mut clocks, Gclk11);
+    let adc1_settings = Config::new()
+        .clock_cycles_per_sample(5)
+        .clock_divider(Prescaler::Div32)
+        .sample_resolution(Resolution::_12bit)
+        .accumulation_method(Accumulation::Single);
+
+    let mut adc1 = Adc::adc(peripherals.adc1, &mut peripherals.mclk, &mut clocks, Gclk11);
     let mut joystick = pins.joystick.init();
 
     // neopixels

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -39,7 +39,8 @@ fn main() -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div64)
+        // Overruns if clock divider < 128 in debug mode
+        .clock_divider(Prescaler::Div128)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
 
     let adc_settings = Config::new()
         .clock_cycles_per_sample(5)
-        .clock_divider(Prescaler::Div32)
+        .clock_divider(Prescaler::Div64)
         .sample_resolution(Resolution::_12bit)
         .accumulation_method(Accumulation::Single);
 

--- a/hal/src/peripherals/adc/d11/mod.rs
+++ b/hal/src/peripherals/adc/d11/mod.rs
@@ -5,8 +5,6 @@ use super::{
 };
 
 use crate::{calibration, pac};
-use pac::adc::avgctrl::Samplenumselect;
-use pac::adc::ctrlb::Resselselect;
 use pac::adc::inputctrl::Gainselect;
 use pac::Peripherals;
 pub mod pin;

--- a/hal/src/peripherals/adc/d5x/mod.rs
+++ b/hal/src/peripherals/adc/d5x/mod.rs
@@ -221,7 +221,7 @@ impl<I: AdcInstance, T> Adc<I, T> {
 
     #[inline]
     pub(super) fn disable_freerunning(&mut self) {
-        self.adc.ctrlb().modify(|_, w| w.freerun().set_bit());
+        self.adc.ctrlb().modify(|_, w| w.freerun().clear_bit());
         self.sync();
     }
 

--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -156,8 +156,8 @@ impl<I: AdcInstance> Adc<I, NoneT> {
     /// ## Important
     ///
     /// This function will return `Err` if the clock source provided
-    /// is faster than 100 MHz, since this is the maximum frequency for GCLK_ADCx
-    /// as per the datasheet.
+    /// is faster than 100 MHz, since this is the maximum frequency for
+    /// GCLK_ADCx as per the datasheet.
     ///
     /// The [`new`](Self::new) function currently takes an `&` reference to a
     /// [`Pclk`](crate::clock::v2::pclk::Pclk). In the future this will likely
@@ -174,13 +174,14 @@ impl<I: AdcInstance> Adc<I, NoneT> {
         clk: crate::clock::v2::apb::ApbClk<I::ClockId>,
         pclk: &crate::clock::v2::pclk::Pclk<I::ClockId, PS>,
     ) -> Result<Self, Error> {
-        // TODO: Ideally, the ADC struct would take ownership of the Pclk type here. However, since
-        // clock::v2 is not implemented for all chips yet, the generics for the Adc type would be
-        // different between chip families, leading to massive and unnecessary code duplication. In
-        // the meantime, we use a "lite" variation of the typelevel guarantees laid out by the
-        // clock::v2 module, meaning that we can guarantee that the clocks are enabled at the time
-        // of creation of the Adc struct; however we can't guarantee that the clock will stay
-        // enabled for the duration of its lifetime.
+        // TODO: Ideally, the ADC struct would take ownership of the Pclk type here.
+        // However, since clock::v2 is not implemented for all chips yet, the
+        // generics for the Adc type would be different between chip families,
+        // leading to massive and unnecessary code duplication. In the meantime,
+        // we use a "lite" variation of the typelevel guarantees laid out by the
+        // clock::v2 module, meaning that we can guarantee that the clocks are enabled
+        // at the time of creation of the Adc struct; however we can't guarantee
+        // that the clock will stay enabled for the duration of its lifetime.
 
         if pclk.freq() > fugit::HertzU32::from_raw(100_000_000) {
             // Clock source is too fast

--- a/hal/src/peripherals/calibration/d11.rs
+++ b/hal/src/peripherals/calibration/d11.rs
@@ -31,6 +31,7 @@ fn cal_with_errata(
 }
 
 /// ADC Linearity Calibration. Should be written to ADC CALIB register.
+#[allow(clippy::unusual_byte_groupings)]
 pub fn adc_linearity_cal() -> u8 {
     // Value in flash is bits 34:27, which spans a 32b boundary
     


### PR DESCRIPTION
Fix a few remaining bugs in the buffered read implementations. Also discovered that the async `read_buffer` method overflows on a D21 target for clock prescalers <= 64 in debug mode. Fixed the examples such that they will always work regardless of optimization level.