### PR TITLE
feat(clock)!: Dynamic PCLK source ID

### DIFF
--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -83,7 +83,7 @@ type Aux = mcan::bus::Aux<
     clock::types::Can1,
     hal::can::Dependencies<
         clock::types::Can1,
-        clock::gclk::Gclk0Id,
+        clock::pclk::PclkSource<clock::gclk::Gclk0Id>,
         bsp::Ata6561Rx,
         bsp::Ata6561Tx,
         bsp::pac::Can1,

--- a/boards/examples/m4-adc.rs
+++ b/boards/examples/m4-adc.rs
@@ -51,13 +51,13 @@ fn main() -> ! {
         // Overruns if clock divider < 32 in debug mode
         .with_clock_divider(Prescaler::Div32)
         .with_vref(atsamd_hal::adc::Reference::Arefa)
-        .enable(peripherals.adc0, apb_adc0, &pclk_adc0)
+        .enable(peripherals.adc0, apb_adc0, pclk_adc0)
         .unwrap();
     let mut adc_pin = pins.a0.into_alternate();
 
     loop {
-        let res = adc.read(&mut adc_pin);
+        let _res = adc.read(&mut adc_pin);
         #[cfg(feature = "use_semihosting")]
-        let _ = cortex_m_semihosting::hprintln!("ADC value: {}", res);
+        let _ = cortex_m_semihosting::hprintln!("ADC value: {}", _res);
     }
 }

--- a/boards/feather_m0/examples/adc.rs
+++ b/boards/feather_m0/examples/adc.rs
@@ -2,8 +2,6 @@
 #![no_main]
 
 use atsamd_hal::adc::AdcBuilder;
-use atsamd_hal::clock::v2::clock_system_at_reset;
-use atsamd_hal::clock::v2::pclk::Pclk;
 use feather_m0 as bsp;
 
 use bsp::hal;
@@ -18,33 +16,60 @@ use bsp::entry;
 use bsp::Pins;
 use pac::{CorePeripherals, Peripherals};
 
-use hal::{
-    adc::{Accumulation, Prescaler},
+use hal::adc::{Accumulation, Prescaler};
+use hal::clock::v2::{
+    self as clock,
+    dfll::Dfll,
+    gclk::{Gclk, GclkDiv8},
+    pclk::Pclk,
 };
 
 #[entry]
 fn main() -> ! {
-    let peripherals = Peripherals::take().unwrap();
+    let device = Peripherals::take().unwrap();
     let _core = CorePeripherals::take().unwrap();
 
-    let pins = Pins::new(peripherals.port);
+    let pins = Pins::new(device.port);
 
+    // IMPORTANT - If reclocking the CPU itself, set wait state to half to avoid
+    // hard faults.
+    device
+        .nvmctrl
+        .ctrlb()
+        .modify(|_, w| w.rws().variant(pac::nvmctrl::ctrlb::Rwsselect::Half));
 
-    let (_buses, clocks, tokens) = clock_system_at_reset(peripherals.gclk, peripherals.pm, peripherals.sysctrl);
-    let (adc_pclk, _gclk0) = Pclk::enable(tokens.pclks.adc, clocks.gclk0);
+    // --- Clocks setup ---
+    let (_buses, clocks, tokens) =
+        clock::clock_system_at_reset(device.gclk, device.pm, device.sysctrl);
+
+    // We will use the internal 8 MHz oscillator on GCLK3 to clock the CPU
+    //
+    // Clock GCLK3 down from 1Mhz to 10000Hz (Div 100), this gives us a
+    // clean factor of 48Mhz for DFLL to use
+    let (gclk3, osc) = Gclk::from_source(tokens.gclks.gclk3, clocks.osc);
+    let gclk3_10k = gclk3.div(GclkDiv8::Div(100)).enable();
+
+    let (pclk_dfll, _gclk3_10k) = Pclk::enable(tokens.pclks.dfll, gclk3_10k);
+    // Start the DFLL at 48Mhz
+    let dfll_48m = Dfll::from_pclk(tokens.dfll, pclk_dfll).enable();
+    // Swap CPU clock source
+    let (gclk0_48, _osc, _dfll_48m) = clocks.gclk0.swap_sources(osc, dfll_48m);
+
+    // --- ADC Configuration ---
+    let (adc_pclk, _gclk0_48) = Pclk::enable(tokens.pclks.adc, gclk0_48);
     let adc_apb = clocks.apbs.adc0;
-    
+
     let mut adc = AdcBuilder::new(Accumulation::single(atsamd_hal::adc::AdcResolution::_12))
         .with_clock_cycles_per_sample(5)
         .with_clock_divider(Prescaler::Div128)
         .with_vref(atsamd_hal::adc::Reference::Intvcc0)
-        .enable(peripherals.adc, adc_apb, &adc_pclk)
+        .enable(device.adc, adc_apb, adc_pclk)
         .unwrap();
     let mut adc_pin = pins.a0.into_alternate();
 
     loop {
-        let res = adc.read(&mut adc_pin);
+        let _res = adc.read(&mut adc_pin);
         #[cfg(feature = "use_semihosting")]
-        cortex_m_semihosting::hprintln!("ADC value: {}", read).unwrap();
+        cortex_m_semihosting::hprintln!("ADC value: {}", _res).unwrap();
     }
 }

--- a/boards/feather_m0/examples/async_adc.rs
+++ b/boards/feather_m0/examples/async_adc.rs
@@ -2,8 +2,6 @@
 #![no_main]
 
 use atsamd_hal::adc::AdcBuilder;
-use atsamd_hal::clock::v2::clock_system_at_reset;
-use atsamd_hal::clock::v2::pclk::Pclk;
 use feather_m0 as bsp;
 
 use bsp::hal;
@@ -19,6 +17,12 @@ use pac::{CorePeripherals, Peripherals};
 
 use hal::{
     adc::{Accumulation, Adc0, Prescaler},
+    clock::v2::{
+        self as clock,
+        dfll::Dfll,
+        gclk::{Gclk, GclkDiv8},
+        pclk::Pclk,
+    },
 };
 
 atsamd_hal::bind_interrupts!(struct Irqs {
@@ -27,27 +31,51 @@ atsamd_hal::bind_interrupts!(struct Irqs {
 
 #[embassy_executor::main]
 async fn main(_s: embassy_executor::Spawner) -> ! {
-    let peripherals = Peripherals::take().unwrap();
+    let device = Peripherals::take().unwrap();
     let _core = CorePeripherals::take().unwrap();
 
-    let pins = Pins::new(peripherals.port);
+    let pins = Pins::new(device.port);
 
-    let (_buses, clocks, tokens) = clock_system_at_reset(peripherals.gclk, peripherals.pm, peripherals.sysctrl);
-    let (adc_pclk, _gclk0) = Pclk::enable(tokens.pclks.adc, clocks.gclk0);
+    // IMPORTANT - If reclocking the CPU itself, set wait state to half to avoid
+    // hard faults.
+    device
+        .nvmctrl
+        .ctrlb()
+        .modify(|_, w| w.rws().variant(pac::nvmctrl::ctrlb::Rwsselect::Half));
+
+    // --- Clocks setup ---
+    let (_buses, clocks, tokens) =
+        clock::clock_system_at_reset(device.gclk, device.pm, device.sysctrl);
+
+    // We will use the internal 8 MHz oscillator on GCLK3 to clock the CPU
+    //
+    // Clock GCLK3 down from 1Mhz to 10000Hz (Div 100), this gives us a
+    // clean factor of 48Mhz for DFLL to use
+    let (gclk3, osc) = Gclk::from_source(tokens.gclks.gclk3, clocks.osc);
+    let gclk3_10k = gclk3.div(GclkDiv8::Div(100)).enable();
+
+    let (pclk_dfll, _gclk3_10k) = Pclk::enable(tokens.pclks.dfll, gclk3_10k);
+    // Start the DFLL at 48Mhz
+    let dfll_48m = Dfll::from_pclk(tokens.dfll, pclk_dfll).enable();
+    // Swap CPU clock source
+    let (gclk0_48, _osc, _dfll_48m) = clocks.gclk0.swap_sources(osc, dfll_48m);
+
+    // --- ADC Configuration ---
+    let (adc_pclk, _gclk0_48) = Pclk::enable(tokens.pclks.adc, gclk0_48);
     let adc_apb = clocks.apbs.adc0;
-    
+
     let mut adc = AdcBuilder::new(Accumulation::single(atsamd_hal::adc::AdcResolution::_12))
         .with_clock_cycles_per_sample(5)
         .with_clock_divider(Prescaler::Div128)
         .with_vref(atsamd_hal::adc::Reference::Intvcc0)
-        .enable(peripherals.adc, adc_apb, &adc_pclk)
+        .enable(device.adc, adc_apb, adc_pclk)
         .unwrap()
         .into_future(Irqs);
     let mut adc_pin = pins.a0.into_alternate();
 
     loop {
-        let res = adc.read(&mut adc_pin).await;
+        let _res = adc.read(&mut adc_pin).await;
         #[cfg(feature = "use_semihosting")]
-        cortex_m_semihosting::hprintln!("ADC Result: {}", res).unwrap();
+        cortex_m_semihosting::hprintln!("ADC Result: {}", _res).unwrap();
     }
 }

--- a/boards/metro_m4/examples/async_adc.rs
+++ b/boards/metro_m4/examples/async_adc.rs
@@ -42,21 +42,21 @@ async fn main(_s: embassy_executor::Spawner) -> ! {
     let apb_adc0 = buses.apb.enable(tokens.apbs.adc0);
     // ...and enable the ADC0 PCLK. Both of these are required for the
     // ADC to run.
-    let (pclk_adc0, _gclk0) = Pclk::enable(tokens.pclks.adc0, clocks.gclk0);
+    let (pclk_adc0, _gclk0) = Pclk::enable_dyn(tokens.pclks.adc0, clocks.gclk0);
 
     let mut adc = AdcBuilder::new(Accumulation::single(atsamd_hal::adc::AdcResolution::_12))
         .with_clock_cycles_per_sample(5)
         .with_clock_divider(Prescaler::Div32)
         .with_vref(atsamd_hal::adc::Reference::Arefa)
-        .enable(peripherals.adc0, apb_adc0, &pclk_adc0)
+        .enable(peripherals.adc0, apb_adc0, pclk_adc0)
         .unwrap()
         .into_future(Irqs);
 
     let mut adc_pin = pins.a0.into_alternate();
 
     loop {
-        let res = adc.read(&mut adc_pin).await;
+        let _res = adc.read(&mut adc_pin).await;
         #[cfg(feature = "use_semihosting")]
-        cortex_m_semihosting::hprintln!("ADC Result: {}", res).unwrap();
+        cortex_m_semihosting::hprintln!("ADC Result: {}", _res).unwrap();
     }
 }

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -2,8 +2,7 @@
 #![no_main]
 
 use atsamd_hal::adc::AdcBuilder;
-use atsamd_hal::clock::v2::clock_system_at_reset;
-use atsamd_hal::clock::v2::pclk::Pclk;
+use atsamd_hal::adc::Reference;
 use samd11_bare as bsp;
 
 use bsp::hal;
@@ -20,25 +19,53 @@ use pac::{CorePeripherals, Peripherals};
 
 use hal::{
     adc::{Accumulation, Prescaler},
+    clock::v2::{
+        self as clock,
+        dfll::Dfll,
+        gclk::{Gclk, GclkDiv8},
+        pclk::Pclk,
+    },
 };
 
 #[entry]
 fn main() -> ! {
-    let peripherals = Peripherals::take().unwrap();
+    let device = Peripherals::take().unwrap();
     let _core = CorePeripherals::take().unwrap();
 
-    let pins = Pins::new(peripherals.port);
+    let pins = Pins::new(device.port);
 
+    // IMPORTANT - If reclocking the CPU itself, set wait state to half to avoid hard faults.
+    device
+        .nvmctrl
+        .ctrlb()
+        .modify(|_, w| w.rws().variant(pac::nvmctrl::ctrlb::Rwsselect::Half));
 
-    let (_buses, clocks, tokens) = clock_system_at_reset(peripherals.gclk, peripherals.pm, peripherals.sysctrl);
-    let (adc_pclk, _gclk0) = Pclk::enable(tokens.pclks.adc, clocks.gclk0);
+    // --- Clocks setup ---
+    let (_buses, clocks, tokens) =
+        clock::clock_system_at_reset(device.gclk, device.pm, device.sysctrl);
+
+    // We will use the internal 8 MHz oscillator on GCLK3 to clock the CPU
+    //
+    // Clock GCLK3 down from 1Mhz to 10000Hz (Div 100), this gives us a
+    // clean factor of 48Mhz for DFLL to use
+    let (gclk3, osc) = Gclk::from_source(tokens.gclks.gclk3, clocks.osc);
+    let gclk3_10k = gclk3.div(GclkDiv8::Div(100)).enable();
+
+    let (pclk_dfll, _gclk3_10k) = Pclk::enable(tokens.pclks.dfll, gclk3_10k);
+    // Start the DFLL at 48Mhz
+    let dfll_48m = Dfll::from_pclk(tokens.dfll, pclk_dfll).enable();
+    // Swap CPU clock source
+    let (gclk0_48, _osc, _dfll_48m) = clocks.gclk0.swap_sources(osc, dfll_48m);
+
+    // --- ADC Configuration ---
+    let (adc_pclk, _gclk0_48) = Pclk::enable(tokens.pclks.adc, gclk0_48);
     let adc_apb = clocks.apbs.adc0;
-    
+
     let mut adc = AdcBuilder::new(Accumulation::single(atsamd_hal::adc::AdcResolution::_12))
         .with_clock_cycles_per_sample(5)
         .with_clock_divider(Prescaler::Div128)
-        .with_vref(atsamd_hal::adc::Reference::Arefa)
-        .enable(peripherals.adc, adc_apb, &adc_pclk)
+        .with_vref(Reference::Intvcc0)
+        .enable(device.adc, adc_apb, adc_pclk)
         .unwrap();
     let mut adc_pin = pins.d1.into_alternate();
 

--- a/hal/src/clock/v2/gclk.rs
+++ b/hal/src/clock/v2/gclk.rs
@@ -1585,6 +1585,7 @@ macro_rules! make_all_gclks {
             ///
             /// `DynGclkId` is the value-level equivalent of [`GclkId`].
             #[hal_macro_helper]
+            #[derive(Clone, Copy, Debug, PartialEq)]
             pub enum DynGclkId {
                 #(
                     Gclk~N,

--- a/hal/src/clock/v2/reset_thumbv6m.rs
+++ b/hal/src/clock/v2/reset_thumbv6m.rs
@@ -6,7 +6,10 @@ use atsamd_hal_macros::hal_macro_helper;
 
 use typenum::U1;
 
-use crate::pac::{Gclk, Pm, Sysctrl};
+use crate::{
+    clock::v2::pclk::PclkSource,
+    pac::{Gclk, Pm, Sysctrl},
+};
 
 use super::*;
 
@@ -97,7 +100,7 @@ pub struct Clocks {
     /// Always-enabled OSCULP oscillators
     pub osculp: OscUlpClocks,
     /// [`Pclk`](pclk::Pclk) for the watchdog timer, sourced from [`Gclk2`](gclk::Gclk2)
-    pub wdt: pclk::Pclk<types::Wdt, gclk::Gclk2Id>,
+    pub wdt: pclk::Pclk<types::Wdt, PclkSource<gclk::Gclk2Id>>,
 }
 
 /// Type-level tokens for unused clocks at power-on reset
@@ -155,7 +158,7 @@ pub fn clock_system_at_reset(gclk: Gclk, pm: Pm, sysctrl: Sysctrl) -> (Buses, Cl
         let osculp32k = Enabled::<_, U0>::new(osculp32k::OscUlp32k::new());
         let (gclk2, osculp32k) = gclk::Gclk2::from_source(gclk::GclkToken::new(), osculp32k);
         let gclk2 = Enabled::new(gclk2);
-        let wdt = pclk::Pclk::new(pclk::PclkToken::new(), gclk2.freq());
+        let wdt = pclk::Pclk::<_, PclkSource<_>>::new(pclk::PclkToken::new(), gclk2.freq());
         let osculp = OscUlpClocks {
             base,
             osculp1k,

--- a/hal/src/peripherals/adc/builder.rs
+++ b/hal/src/peripherals/adc/builder.rs
@@ -1,5 +1,7 @@
 use atsamd_hal_macros::hal_cfg;
 
+use crate::clock::v2::{apb::ApbClk, pclk::DynPclk};
+
 #[hal_cfg("adc-d5x")]
 use crate::pac::adc0;
 
@@ -13,9 +15,7 @@ pub use adc0::ctrlb::Prescalerselect as Prescaler;
 pub use adc0::ctrla::Prescalerselect as Prescaler;
 
 pub use adc0::avgctrl::Samplenumselect as SampleCount;
-
 pub use adc0::ctrlb::Resselselect as Resolution;
-
 pub use adc0::refctrl::Refselselect as Reference;
 
 use super::{Adc, AdcInstance};
@@ -244,15 +244,18 @@ impl AdcBuilder {
         Ok(adc_clk_freq / clocks_per_sample)
     }
 
-    /// Turn the builder into an ADC
+    /// Turn the builder into an ADC.
+    ///
+    /// This function will convert the provided
+    /// [`Pclk`](crate::clock::v2::pclk::Pclk) into a [`DynPclk`](crate::clock::v2::pclk::DynPclk).
     #[inline]
-    pub fn enable<I: AdcInstance, PS: crate::clock::v2::pclk::PclkSourceId>(
+    pub fn enable<I: AdcInstance>(
         self,
         adc: I::Instance,
-        clk: crate::clock::v2::apb::ApbClk<I::ClockId>,
-        pclk: &crate::clock::v2::pclk::Pclk<I::ClockId, PS>,
+        clk: ApbClk<I::ClockId>,
+        pclk: impl Into<DynPclk<I::ClockId>>,
     ) -> Result<Adc<I>, BuilderError> {
         let settings = self.to_settings()?;
-        Adc::new(adc, settings, clk, pclk).map_err(|e| e.into())
+        Adc::new(adc, settings, clk, pclk.into()).map_err(|e| e.into())
     }
 }

--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -27,7 +27,12 @@ use core::ops::Deref;
 use atsamd_hal_macros::{hal_cfg, hal_module};
 use pac::Peripherals;
 
-use crate::{gpio::AnyPin, pac, typelevel::Sealed};
+use crate::{
+    clock::v2::{apb::ApbClk, pclk::DynPclk},
+    gpio::AnyPin,
+    pac,
+    typelevel::Sealed,
+};
 
 #[hal_module(
     any("adc-d11", "adc-d21") => "d11/mod.rs",
@@ -161,6 +166,7 @@ where
 pub struct Adc<I: AdcInstance> {
     adc: I::Instance,
     _apbclk: crate::clock::v2::apb::ApbClk<I::ClockId>,
+    _pclk: crate::clock::v2::pclk::DynPclk<I::ClockId>,
     cfg: AdcSettings,
     discard: bool,
 }
@@ -189,11 +195,11 @@ impl<I: AdcInstance> Adc<I> {
     /// frequency for the ADC is restricted to 90Mhz for stable performance.
     #[inline]
     #[atsamd_hal_macros::hal_macro_helper]
-    pub(crate) fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
+    pub(crate) fn new(
         adc: I::Instance,
         settings: AdcSettings,
         clk: crate::clock::v2::apb::ApbClk<I::ClockId>,
-        pclk: &crate::clock::v2::pclk::Pclk<I::ClockId, PS>,
+        pclk: crate::clock::v2::pclk::DynPclk<I::ClockId>,
     ) -> Result<Self, Error> {
         // TODO: Ideally, the ADC struct would take ownership of the Pclk type here.
         // However, since clock::v2 is not implemented for all chips yet, the
@@ -218,6 +224,7 @@ impl<I: AdcInstance> Adc<I> {
         let mut new_adc = Self {
             adc,
             _apbclk: clk,
+            _pclk: pclk,
             cfg: settings,
             discard: true,
         };
@@ -369,9 +376,9 @@ impl<I: AdcInstance> Adc<I> {
 
     /// Return the underlying ADC PAC object and the enabled APB ADC clock.
     #[inline]
-    pub fn free(mut self) -> (I::Instance, crate::clock::v2::apb::ApbClk<I::ClockId>) {
+    pub fn free(mut self) -> (I::Instance, ApbClk<I::ClockId>, DynPclk<I::ClockId>) {
         self.software_reset();
-        (self.adc, self._apbclk)
+        (self.adc, self._apbclk, self._pclk)
     }
 
     /// Reset the peripheral.


### PR DESCRIPTION
PCLK source ID can be either type-checked or runtime-checked. Also change ADC peripehral to use dynamic source IDs.

Detailed description: https://github.com/atsamd-rs/atsamd/pull/978